### PR TITLE
Disable weak algorithms for apiman

### DIFF
--- a/apiman-wildfly/Dockerfile
+++ b/apiman-wildfly/Dockerfile
@@ -6,7 +6,8 @@ ENV APIMAN_VERSION 1.1.6.Final
 RUN cd $JBOSS_HOME \
  && curl http://downloads.jboss.org/overlord/apiman/$APIMAN_VERSION/apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip -o apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
  && bsdtar -xf apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
- && rm apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip
+ && rm apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
+ && echo "jdk.tls.disabledAlgorithms=RC4,ECDHE,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,TLS_ECDHE_RSA_WITH_RC4_128_SHA,TLS_ECDH_ECDSA_WITH_RC4_128_SHA,TLS_ECDH_RSA_WITH_RC4_128_SHA,TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA" >>  $JAVA_HOME/jre/lib/security/java.security
 
 CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-c", "standalone-apiman.xml"]
 


### PR DESCRIPTION
Some setups seem to choose unsafe crypto algorithms, so we should disable them (see https://issues.jboss.org/browse/APIMAN-593).

This was the solution reached in conjunction with @jorgemoralespou 

One other possibility is to push this change into the Java 7 base image, but I would think that would be too risky (law of unintended consequences!).

Thanks
